### PR TITLE
Fix regressions resulting from screen sharing changes

### DIFF
--- a/src/common/guac_cursor.c
+++ b/src/common/guac_cursor.c
@@ -359,3 +359,12 @@ void guac_common_cursor_set_blank(guac_common_cursor* cursor) {
 
 }
 
+void guac_common_cursor_remove_user(guac_common_cursor* cursor,
+        guac_user* user) {
+
+    /* Disassociate from given user */
+    if (cursor->user == user)
+        cursor->user = NULL;
+
+}
+

--- a/src/common/guac_cursor.h
+++ b/src/common/guac_cursor.h
@@ -249,4 +249,19 @@ void guac_common_cursor_set_ibar(guac_common_cursor* cursor);
  */
 void guac_common_cursor_set_blank(guac_common_cursor* cursor);
 
+/**
+ * Removes the given user, such that future synchronization will not occur.
+ * This is necessary when a user leaves the connection. If a user leaves the
+ * connection and this is not called, the corresponding guac_user and socket
+ * may cease to be valid, and future synchronization attempts will segfault.
+ *
+ * @param cursor
+ *     The cursor to remove the user from.
+ *
+ * @param user
+ *     The user to remove.
+ */
+void guac_common_cursor_remove_user(guac_common_cursor* cursor,
+        guac_user* user);
+
 #endif

--- a/src/common/guac_cursor.h
+++ b/src/common/guac_cursor.h
@@ -252,8 +252,8 @@ void guac_common_cursor_set_blank(guac_common_cursor* cursor);
 /**
  * Removes the given user, such that future synchronization will not occur.
  * This is necessary when a user leaves the connection. If a user leaves the
- * connection and this is not called, the corresponding guac_user and socket
- * may cease to be valid, and future synchronization attempts will segfault.
+ * connection and this is not called, the mouse cursor state may not update
+ * correctly in response to mouse events.
  *
  * @param cursor
  *     The cursor to remove the user from.

--- a/src/protocols/rdp/rdp_settings.c
+++ b/src/protocols/rdp/rdp_settings.c
@@ -859,9 +859,31 @@ void guac_rdp_push_settings(guac_rdp_settings* guac_settings, freerdp* rdp) {
 
     /* Performance flags */
 #ifdef LEGACY_RDPSETTINGS
+
+    /* Explicitly set flag value */
     rdp_settings->performance_flags = guac_rdp_get_performance_flags(guac_settings);
+
+    /* Set individual flags - some FreeRDP versions overwrite the above */
+    rdp_settings->smooth_fonts = guac_settings->font_smoothing_enabled;
+    rdp_settings->disable_wallpaper = !guac_settings->wallpaper_enabled;
+    rdp_settings->disable_full_window_drag = !guac_settings->full_window_drag_enabled;
+    rdp_settings->disable_menu_animations = !guac_settings->menu_animations_enabled;
+    rdp_settings->disable_theming = !guac_settings->theming_enabled;
+    rdp_settings->desktop_composition = !guac_settings->desktop_composition_enabled;
+
 #else
+
+    /* Explicitly set flag value */
     rdp_settings->PerformanceFlags = guac_rdp_get_performance_flags(guac_settings);
+
+    /* Set individual flags - some FreeRDP versions overwrite the above */
+    rdp_settings->AllowFontSmoothing = guac_settings->font_smoothing_enabled;
+    rdp_settings->DisableWallpaper = !guac_settings->wallpaper_enabled;
+    rdp_settings->DisableFullWindowDrag = !guac_settings->full_window_drag_enabled;
+    rdp_settings->DisableMenuAnims = !guac_settings->menu_animations_enabled;
+    rdp_settings->DisableThemes = !guac_settings->theming_enabled;
+    rdp_settings->AllowDesktopComposition = guac_settings->desktop_composition_enabled;
+
 #endif
 
     /* Client name */

--- a/src/protocols/rdp/user.c
+++ b/src/protocols/rdp/user.c
@@ -122,3 +122,12 @@ int guac_rdp_user_file_handler(guac_user* user, guac_stream* stream,
     return 0;
 }
 
+int guac_rdp_user_leave_handler(guac_user* user) {
+
+    guac_rdp_client* rdp_client = (guac_rdp_client*) user->client->data;
+
+    guac_common_cursor_remove_user(rdp_client->display->cursor, user);
+
+    return 0;
+}
+

--- a/src/protocols/rdp/user.h
+++ b/src/protocols/rdp/user.h
@@ -28,6 +28,11 @@
 guac_user_join_handler guac_rdp_user_join_handler;
 
 /**
+ * Handler for leaving users.
+ */
+guac_user_leave_handler guac_rdp_user_leave_handler;
+
+/**
  * Handler for received simple file uploads. This handler will automatically
  * select between RDPDR and SFTP depending on which is available and which has
  * priority given associated settings.

--- a/src/protocols/ssh/ssh.c
+++ b/src/protocols/ssh/ssh.c
@@ -178,8 +178,11 @@ void* ssh_client_thread(void* data) {
     pthread_t input_thread;
 
     /* Init SSH base libraries */
-    if (guac_common_ssh_init(client))
+    if (guac_common_ssh_init(client)) {
+        guac_client_abort(client, GUAC_PROTOCOL_STATUS_SERVER_ERROR,
+                "SSH library initialization failed");
         return NULL;
+    }
 
     /* Set up screen recording, if requested */
     if (settings->recording_path != NULL) {

--- a/src/protocols/ssh/user.c
+++ b/src/protocols/ssh/user.c
@@ -82,3 +82,12 @@ int guac_ssh_user_join_handler(guac_user* user, int argc, char** argv) {
 
 }
 
+int guac_ssh_user_leave_handler(guac_user* user) {
+
+    guac_ssh_client* ssh_client = (guac_ssh_client*) user->client->data;
+
+    guac_common_cursor_remove_user(ssh_client->term->cursor, user);
+
+    return 0;
+}
+

--- a/src/protocols/ssh/user.h
+++ b/src/protocols/ssh/user.h
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-#ifndef GUAC_VNC_USER_H
-#define GUAC_VNC_USER_H
+#ifndef GUAC_SSH_USER_H
+#define GUAC_SSH_USER_H
 
 #include "config.h"
 
@@ -28,6 +28,11 @@
  * Handler for joining users.
  */
 guac_user_join_handler guac_ssh_user_join_handler;
+
+/**
+ * Handler for leaving users.
+ */
+guac_user_leave_handler guac_ssh_user_leave_handler;
 
 #endif
 

--- a/src/protocols/telnet/user.c
+++ b/src/protocols/telnet/user.c
@@ -78,3 +78,13 @@ int guac_telnet_user_join_handler(guac_user* user, int argc, char** argv) {
 
 }
 
+int guac_telnet_user_leave_handler(guac_user* user) {
+
+    guac_telnet_client* telnet_client =
+        (guac_telnet_client*) user->client->data;
+
+    guac_common_cursor_remove_user(telnet_client->term->cursor, user);
+
+    return 0;
+}
+

--- a/src/protocols/telnet/user.h
+++ b/src/protocols/telnet/user.h
@@ -29,5 +29,10 @@
  */
 guac_user_join_handler guac_telnet_user_join_handler;
 
+/**
+ * Handler for leaving users.
+ */
+guac_user_leave_handler guac_telnet_user_leave_handler;
+
 #endif
 

--- a/src/protocols/vnc/client.c
+++ b/src/protocols/vnc/client.c
@@ -52,6 +52,7 @@ int guac_client_init(guac_client* client) {
 
     /* Set handlers */
     client->join_handler = guac_vnc_user_join_handler;
+    client->leave_handler = guac_vnc_user_leave_handler;
     client->free_handler = guac_vnc_client_free_handler;
 
     return 0;

--- a/src/protocols/vnc/user.c
+++ b/src/protocols/vnc/user.c
@@ -97,3 +97,12 @@ int guac_vnc_user_join_handler(guac_user* user, int argc, char** argv) {
 
 }
 
+int guac_vnc_user_leave_handler(guac_user* user) {
+
+    guac_vnc_client* vnc_client = (guac_vnc_client*) user->client->data;
+
+    guac_common_cursor_remove_user(vnc_client->display->cursor, user);
+
+    return 0;
+}
+

--- a/src/protocols/vnc/user.h
+++ b/src/protocols/vnc/user.h
@@ -29,5 +29,10 @@
  */
 guac_user_join_handler guac_vnc_user_join_handler;
 
+/**
+ * Handler for leaving users.
+ */
+guac_user_leave_handler guac_vnc_user_leave_handler;
+
 #endif
 


### PR DESCRIPTION
This change addresses the following regressions:
1. RDP performance flags do not have an effect for certain versions of FreeRDP.
2. The mouse cursor is duplicated when a user quickly disconnects and rejoins the connection.
3. The Guacamole side of an RDP connection (as well as other protocols under rarer conditions) remains open even though the RDP side has closed (by clicking "Disconnect" in the start menu, for example).
